### PR TITLE
Make use of .prop() with the checked property

### DIFF
--- a/modules/frame.js
+++ b/modules/frame.js
@@ -237,10 +237,10 @@
 
         // Select / deselect all the things
         $('#select-all').click(function () {
-            $frameSitetable.find('.thing:visible input[type=checkbox]').attr('checked', allSelected = this.checked);
+            $frameSitetable.find('.thing:visible input[type=checkbox]').prop('checked', allSelected = this.checked);
         });
         $frameSitetable.find('.thing input[type=checkbox]').live('click', function () {
-            $('#select-all').attr('checked', allSelected = !$('.thing:visible input[type=checkbox]').not(':checked').length);
+            $('#select-all').prop('checked', allSelected = !$('.thing:visible input[type=checkbox]').not(':checked').length);
         });
 
         // Select/deselect certain things
@@ -296,11 +296,11 @@
                     selector = ':has(.linkflair)';
                     break;
             }
-            things.filter(selector).find('input[type=checkbox]').attr('checked', true);
+            things.filter(selector).find('input[type=checkbox]').prop('checked', true);
         });
         $('.hide-selected').click(function () {
             $frameSitetable.find('.thing:visible:has(input:checked)').hide();
-            $frameSitetable.find('.thing input[type=checkbox]').attr('checked', false);
+            $frameSitetable.find('.thing input[type=checkbox]').prop('checked', false);
         });
         $('.unhide-selected').click(function () {
             $frameSitetable.find('.thing').show();
@@ -332,7 +332,7 @@
         // Uncheck anything we've taken an action, if it's checked.
         $('.pretty-button').live('click', function (e) {
             var thing = $(this).closest('.thing');
-            $(thing).find('input[type=checkbox]').attr('checked', false);
+            $(thing).find('input[type=checkbox]').prop('checked', false);
             if (hideActionedItems) {
                 $(thing).hide();
             } else if (ignoreOnApproveset) {

--- a/modules/queuetools.js
+++ b/modules/queuetools.js
@@ -214,10 +214,10 @@ function queuetools() {
 
         // Select / deselect all the things
         $('#select-all').click(function () {
-            $('.thing:visible input[type=checkbox]').attr('checked', allSelected = this.checked);
+            $('.thing:visible input[type=checkbox]').prop('checked', allSelected = this.checked);
         });
         $body.on('click', '.thing input[type=checkbox]', function () {
-            $('#select-all').attr('checked', allSelected = !$('.thing:visible input[type=checkbox]').not(':checked').length);
+            $('#select-all').prop('checked', allSelected = !$('.thing:visible input[type=checkbox]').not(':checked').length);
         });
 
         // Select/deselect certain things
@@ -273,11 +273,11 @@ function queuetools() {
                     selector = ':has(.linkflair)';
                     break;
             }
-            things.filter(selector).find('input[type=checkbox]').attr('checked', true);
+            things.filter(selector).find('input[type=checkbox]').prop('checked', true);
         });
         $('.hide-selected').click(function () {
             $('.thing:visible:has(input:checked)').hide();
-            $('.thing input[type=checkbox]').attr('checked', false);
+            $('.thing input[type=checkbox]').prop('checked', false);
         });
         $('.unhide-selected').click(function () {
             $things.show();
@@ -309,7 +309,7 @@ function queuetools() {
         // Uncheck anything we've taken an action, if it's checked.
         $body.on('click', '.pretty-button', function (e) {
             var thing = $(this).closest('.thing');
-            $(thing).find('input[type=checkbox]').attr('checked', false);
+            $(thing).find('input[type=checkbox]').prop('checked', false);
             if (hideActionedItems) {
                 $(thing).hide();
             } else if (ignoreOnApproveset) {

--- a/modules/removalreasons.js
+++ b/modules/removalreasons.js
@@ -287,7 +287,7 @@ function removalreasons() {
         function openPopup() {
             // Reset state
             popup.find('attrs').attr(data);
-            popup.find('.selectable-reason input[type=checkbox]:checked').attr('checked', false);
+            popup.find('.selectable-reason input[type=checkbox]:checked').prop('checked', false);
             popup.find('.selectable-reason.reason-selected').removeClass('reason-selected');
             popup.find('.status').hide();//css('display: none;');
             popup.find('.error-highlight').removeClass('error-highlight');


### PR DESCRIPTION
Make use of `.prop()` with the `checked` property for #279.

Tested in Safari and Chrome.
