### PR TITLE
Clicking on an open settings tab won't clear its content

### DIFF
--- a/modules/notifier.js
+++ b/modules/notifier.js
@@ -682,7 +682,7 @@ function notifier() {
     });
 
     // change tabs
-    $body.on('click', '.tb-window-tabs a', function () {
+    $body.on('click', '.tb-window-tabs a:not(.active)', function () {
         var tab = $(this).attr('class'),
             $tb_help_mains = $('.tb-help-main');
 


### PR DESCRIPTION
I didn't notice a reason to have the tabs reload so it might as well be the best way to simply don't react on the active tabs for #285.

Tested in Safari and Chrome.
