### PR TITLE
Enable ace editor on automoderator-schedule page

### DIFF
--- a/modules/syntax.js
+++ b/modules/syntax.js
@@ -105,7 +105,7 @@ self.init = function () {
         });
     }
 
-    if (location.pathname.match(/\/wiki\/edit\/automoderator\/?$/)
+    if (location.pathname.match(/\/wiki\/edit\/automoderator(-schedule)?\/?$/)
         || location.pathname.match(/\/wiki\/edit\/toolbox\/?$/)
     ) {
         var $editform = $('#editform');
@@ -121,7 +121,7 @@ self.init = function () {
         }
         editor.setTheme("ace/theme/" + selectedTheme);
 
-        if (location.pathname.match(/\/wiki\/edit\/automoderator\/?$/)) {
+        if (location.pathname.match(/\/wiki\/edit\/automoderator(-schedule)?\/?$/)) {
             session.setMode("ace/mode/yaml");
         }
         if (location.pathname.match(/\/wiki\/edit\/toolbox\/?$/)) {


### PR DESCRIPTION
Automoderator also has a scheduling function which is controlled by the the /wiki/automoderator-schedule page.

I saw that [under some conditions](https://github.com/creesch/reddit-moderator-toolbox/blob/10cfd4d526cdf074b4437076c4fcf5e9253fa1e5/libs/redditapi.js#L96) AM is automatically PM'ed when updating its wiki page. It might also be a good idea to implement the same functionality for the schedule config.