### PR TITLE
Moved modmail & unmoderated icons down a few px

### DIFF
--- a/styles/toolbox.css
+++ b/styles/toolbox.css
@@ -79,6 +79,7 @@
 }
 
 .mod-toolbox #tb-modmail {
+	top: 2px;
     display: inline-block;
     height: 16px;
     overflow: hidden;
@@ -128,7 +129,7 @@
     background-repeat: no-repeat;
     line-height: 8px;
     position: relative;
-    top: 2px;
+    top: 3px;
     display: inline-block;
     text-indent: -9999px;
     overflow: hidden;


### PR DESCRIPTION
Mail, modmail, modqueue and unmoderated icons in the bottom bar should be bottom aligned now.
The icon for removed comments is still 2 pixels too high, but I couldn't figure out how to move it without also moving the counter.