### PR TITLE
Styling of mod menu icons

### DIFF
--- a/modules/config.js
+++ b/modules/config.js
@@ -222,7 +222,7 @@ self.init = function() {
         });
 
         var $toolbox = $('#moderation_tools').find('.content .icon-menu'),
-            configLink = '<li><img class="tb-moderation-tools-icons" src="data:image/png;base64,' + TBui.iconWrench + '"/><span class="separator"></span><a href="javascript:;" class="toolbox-edit" title="toolbox configuration for this subreddit">toolbox configuration</a></li>';
+            configLink = '<li><span class="separator"></span><a href="javascript:;" class="toolbox-edit" title="toolbox configuration for this subreddit"><img class="tb-moderation-tools-icons" src="data:image/png;base64,' + TBui.iconWrench + '"/>toolbox configuration</a></li>';
         $toolbox.append(configLink);
         // If we are not on a subreddit but we are on a queue page we want to add the buttons to the multireddit listing.
     } else if (TBUtils.isModpage) {

--- a/modules/usernotes.js
+++ b/modules/usernotes.js
@@ -437,8 +437,8 @@ self.usernotesManager = function () {
 
     if (showLink && TBUtils.post_site && TBUtils.isMod) {
         var $toolbox = $('#moderation_tools').find('.content .icon-menu'),
-            managerLink = '<li><img src="data:image/png;base64,' + TB.ui.iconUsernotes + '" class="tb-moderation-tools-icons"/><span class="separator"></span>\
-        <a href="/r/' + TBUtils.post_site + '/about/usernotes" class="tb-un-manager" title="edit usernotes for this subreddit">usernotes</a></li>';
+            managerLink = '<li><span class="separator"></span>\
+        <a href="/r/' + TBUtils.post_site + '/about/usernotes" class="tb-un-manager" title="edit usernotes for this subreddit"><img src="data:image/png;base64,' + TB.ui.iconUsernotes + '" class="tb-moderation-tools-icons"/>usernotes</a></li>';
         $toolbox.append(managerLink);
 
     } else if (showLink && TBUtils.isModpage) {

--- a/styles/toolbox.css
+++ b/styles/toolbox.css
@@ -1859,8 +1859,9 @@ body.res-nightmode.mod-page a.pretty-button:focus {
 
 /* This should probably be somewhere else */
 
-#moderation_tools .icon-menu .toolbox-edit {
-    margin-left: 5px;
+#moderation_tools .tb-moderation-tools-icons {
+    margin: 0 5px 0 1px;
+    vertical-align: bottom;
 }
 
 #moderation_tools .icon-menu .tb-un-manager {

--- a/styles/toolbox.css
+++ b/styles/toolbox.css
@@ -1864,10 +1864,6 @@ body.res-nightmode.mod-page a.pretty-button:focus {
     vertical-align: bottom;
 }
 
-#moderation_tools .icon-menu .tb-un-manager {
-    margin-left: 1px;
-}
-
 /* metrics tab/dropdown stuff */
 #tb-metrics-expand-list {
     display: none;


### PR DESCRIPTION
Makes the mod menu icons consistent with Reddit's markup.

Previously the image tag was being inserted before `span.separator` which was inconsistent with Reddit's default markup for the menu.

This screenshot shows the difference it makes; using custom CSS to style the menu. It also means the icons can be clicked, whereas before you had to click the text.
![modtools-icon](https://cloud.githubusercontent.com/assets/7245595/10392009/9a0cac40-6ec6-11e5-823a-a75f39582830.png)