### PR TITLE
Add missing syntax specifier to user history table

### DIFF
--- a/extension/data/modules/historybutton.js
+++ b/extension/data/modules/historybutton.js
@@ -407,7 +407,7 @@ self.populateSubmissionHistory = function (after, author) {
         $.each(user.domainList, function (index, value) {
             var domain = value,
                 domainCount = user.domains[domain].count,
-                url = `/search?q=%28and+site%3A%27${domain}%27+author%3A%27${author}%27+is_self%3A0+%29&restrict_sr=off&sort=new&feature=legacy_search`,
+                url = `/search?q=%28and+site%3A%27${domain}%27+author%3A%27${author}%27+is_self%3A0+%29&restrict_sr=off&sort=new&syntax=cloudsearch&feature=legacy_search`,
                 match = domain.match(/^self.(\w+)$/),
                 percentage = Math.round(domainCount / totalDomainCount * 100),
                 bgcolor = '#fff';
@@ -417,7 +417,7 @@ self.populateSubmissionHistory = function (after, author) {
             }
 
             //If the domain is a self post, change the URL
-            if (match) url = `/r/${match[1]}/search?q=%28and+author%3A%27${author}%27+is_self%3A1+%29&restrict_sr=on&sort=new&feature=legacy_search`;
+            if (match) url = `/r/${match[1]}/search?q=%28and+author%3A%27${author}%27+is_self%3A1+%29&restrict_sr=on&sort=new&syntax=cloudsearch&feature=legacy_search`;
 
             //Append domain to the table
             $domainTable.append(


### PR DESCRIPTION
To use structured queries, you need to either write them in the default syntax (lucene), or specify that it's written in the alternate syntax, cloudsearch.  Right now, the tables in user history comments (at least in /r/spam reports) use cloudsearch but don't specify the syntax as such.  This technically works but might cause issues.

Right now, the queries are `(and site:'${domain}' author:'${author}' is_self:0 )` and `(and author:'${author}' is_self:1 )`.  Under normal lucene syntax, it would usually be phrased as `site:${domain} author:${author} is_self:false` and `author:${author} is_self:true`; the current queries aren't lucene but instead cloudsearch.

While reddit _does_ use cloudsearch, it isn't the default syntax, and using it where lucene is expected can have problematic results.  In this case, there doesn't _seem_ to be much of an issue, but it still is being treated as lucene and thus converted to cloudsearch (you can see this in action by hovering over the &delta; near the search results.  For instance, [`(and site:'imgur.com' author:'pokechu22' is_self:0 )`](https://www.reddit.com/search?q=%28and+site%3A%27imgur.com%27+author%3A%27pokechu22%27+is_self%3A0+%29&restrict_sr=off&sort=new&feature=legacy_search) (not a real example, but it is something that could be generated) becomes `(and (field text 'and') (field site 'imgur.com') (field author 'pokechu22') is_self:0)` - note the `(field text 'and')` at the start.  Due to stemming, I think that the additional search for `and` is ignored, but it still may cause issues.

(You may also note that it's using `(field <field name> '<field value>')` - this is essentially the same as using `<field name>:<field value>` and both _are_ allowed in cloudsearch).

The fix is to manually specify the syntax as cloudsearch using `&syntax=cloudsearch`.  This skips the conversion process and just queries it in cloudsearch syntax.

This only matters on those specific queries which have queries that use cloudsearch.  The other ones (on lines 460 and 660) do not use cloudsearch (or mean the same thing regarldess of whether cloudsearch is used) and thus do not need to be changed.

