### PR TITLE
Highlight negative posts

### DIFF
--- a/extension/data/modules/queuetools.js
+++ b/extension/data/modules/queuetools.js
@@ -160,7 +160,6 @@ self.init = function () {
         var score = $this.find(".likes .score.likes, .unvoted .score.unvoted, .dislikes .score.dislikes").html();
         score = /\d+/.test(score) ? parseInt(score) : 1; // If the score is still hidden, we'll assume it's fine
         if (score > 0) return;
-        $this.attr('style', 'background-color: #FDD');
         $this.addClass('tb-zero-highlight');
     }
     if (highlightNegativePosts) {

--- a/extension/data/modules/queuetools.js
+++ b/extension/data/modules/queuetools.js
@@ -153,28 +153,31 @@ self.init = function () {
         }
     });
 
-    // NER for coloring subs.
+    // Negative post highlighting
+    function highlightBadPosts() {
+        var $this = $(this);
+        $this.addClass('highlight-processed');
+        var score = $this.find(".likes .score.likes, .unvoted .score.unvoted, .dislikes .score.dislikes").html();
+        score = /\d+/.test(score) ? parseInt(score) : 1; // If the score is still hidden, we'll assume it's fine
+        if (score > 0) return;
+        $this.attr('style', 'background-color: #FDD');
+        $this.addClass('tb-zero-highlight');
+    }
+    if (highlightNegativePosts) {
+        $('.thing').not('.highlight-processed').each(highlightBadPosts);
+    }
+
+    // NER for these things.
     window.addEventListener("TBNewThings", function () {
         if (subredditColor) {
             self.log('adding sub colors (ner)');
             $(".thing").not(".color-processed").each(colorSubreddits);
         }
+        if (highlightNegativePosts) {
+            self.log('adding zero-score highlights');
+            $('.thing').not('.highlight-processed').each(highlightBadPosts);
+        }
     });
-
-    // Negative post highlighting
-    function highlightBadPosts() {
-        var $this = $(this);
-        $this.addClass('highlight-processed');
-        // This only uses the visible score, so if a score is hidden on the listing, we should assume it's fine, hence this   ↓
-        var score = $this.find(".likes .score.likes, .unvoted .score.unvoted, .dislikes .score.dislikes").html();
-        score = /\d+/.test(score) ? parseInt(score) : 1; // If the score is still hidden, we'll assume it's fine
-        if (score > 0) return;
-        $this.attr('style', 'background-color: #FDD');
-        $this.addClass('tb-negative-highlight');
-    }
-    if (highlightNegativePosts) {
-        $('.thing').not('.highlight-processed').each(highlightBadPosts);
-    }
 
 
     // Ideally, this should be moved somewhere else to be common with the removal reasons module

--- a/extension/data/modules/queuetools.js
+++ b/extension/data/modules/queuetools.js
@@ -4,6 +4,12 @@ self.shortname = 'QueueTools';
 
 self.settings['enabled']['default'] = true;
 
+self.register_setting('highlightNegativePosts', {
+    'type': 'boolean',
+    'default': false,
+    'title': 'Highlight items with a score of 0 or less.'
+})
+
 self.register_setting('hideActionedItems', {
     'type': 'boolean',
     'default': false,
@@ -92,6 +98,7 @@ self.init = function () {
 
     // Cached data
     var notEnabled = [],
+        highlightNegativePosts = self.setting('highlightNegativePosts'),
         hideActionedItems = self.setting('hideActionedItems'),
         showAutomodActionReason = self.setting('showAutomodActionReason'),
         sortUnmoderated = self.setting('sortUnmoderated'),
@@ -153,6 +160,21 @@ self.init = function () {
             $(".thing").not(".color-processed").each(colorSubreddits);
         }
     });
+
+    // Negative post highlighting
+    function highlightBadPosts() {
+        var $this = $(this);
+        $this.addClass('highlight-processed');
+        // This only uses the visible score, so if a score is hidden on the listing, we should assume it's fine, hence this   ↓
+        var score = $this.find(".likes .score.likes, .unvoted .score.unvoted, .dislikes .score.dislikes").html();
+        score = /\d+/.test(score) ? parseInt(score) : 1; // If the score is still hidden, we'll assume it's fine
+        if (score > 0) return;
+        $this.attr('style', 'background-color: #FDD');
+        $this.addClass('tb-negative-highlight');
+    }
+    if (highlightNegativePosts) {
+        $('.thing').not('.highlight-processed').each(highlightBadPosts);
+    }
 
 
     // Ideally, this should be moved somewhere else to be common with the removal reasons module

--- a/extension/data/styles/queuetools.css
+++ b/extension/data/styles/queuetools.css
@@ -178,3 +178,8 @@ a.tb-subreddit-item-count {
     background-color: #9E9C9C;
 }
 
+
+/* Highlight for zero-scored posts */
+.tb-zero-highlight {
+    background: #FDD;
+}


### PR DESCRIPTION
Fixes #579 

Adds a new setting to queue tools that highlights all comments with a score of 0 in a light red. Posts whose scores are hidden from the listing are assumed to be fine.