### PR TITLE
Fix realtime tab being duplicated sometimes

### DIFF
--- a/extension/data/modules/realtime.js
+++ b/extension/data/modules/realtime.js
@@ -16,7 +16,7 @@ self.init = function () {
     if (location.search.match(/before|after/) || $('body.comments-page').length || !(TBUtils.isModpage || TBUtils.isCommentsPage || TBUtils.isNewPage || TBUtils.isUserPage)) return;
 
     // Add checkbox;
-    $('.tabmenu').append('<li><a><label>realtime:<input id="realtime" class="tb-realtime-checkbox" type="checkbox" title="Toggle realtime mode" /></label></a></li>');
+    $('.tabmenu:first-of-type').append('<li><a><label>realtime:<input id="realtime" class="tb-realtime-checkbox" type="checkbox" title="Toggle realtime mode" /></label></a></li>');
 
     var timeout, delay = 5000,
         $checkbox = $('.tb-realtime-checkbox');


### PR DESCRIPTION
Fixes #748 

The cause was RES adding a second `.tabmenu` for the "View Images" button, so by setting it as a child of the first one only, there's only one button now.