### PR TITLE
Make tabs properly deactivate when another is pressed

### DIFF
--- a/extension/data/tbui.js
+++ b/extension/data/tbui.js
@@ -249,7 +249,7 @@
                     var tab = e.data.tab;
 
                     // hide others
-                    $tabs.removeClass('active');
+                    $tabs.find('a').removeClass('active');
                     $popup.find('.tb-popup-tab').hide();
 
                     // show current


### PR DESCRIPTION
Before, the tabs weren't having their active class taken away, so they would stay active forever.

Noticed it in the mod button dialog, I'm sure it effected other places too though.