### PR TITLE
modCheck tests for existence of modmail icons

### DIFF
--- a/extension/data/tbutils.js
+++ b/extension/data/tbutils.js
@@ -18,7 +18,7 @@ function initwrapper() {
         $('body').addClass('mod-toolbox-new-modmail');
         TBUtils.modCheck = true;
     } else {
-        TBUtils.modCheck = $('body').hasClass('res') ? $('#sr-header-area a[href*="/r/mod"]').length > 0 : $('#sr-header-area a[href$="/r/mod"]').length > 0;
+        TBUtils.modCheck = $('#modmail, #new_modmail').length > 0;
     }
     // If we are on new modmail we use www.reddit.com for all other instances we use whatever is the current domain.
     TBUtils.baseDomain = (window.location.hostname === 'mod.reddit.com' ? 'https://www.reddit.com' :  'https://' + window.location.hostname);


### PR DESCRIPTION
This is more reliable than checking for the "mod" link in the subreddit shortcuts, because RES users can opt to remove the "mod" and "modqueue" links, or add links to subreddits like /r/modfoobar.