### PR TITLE
Resolves Reddit sometimes providing a relative URL to its own posts.

### DIFF
--- a/extension/data/tbutils.js
+++ b/extension/data/tbutils.js
@@ -925,7 +925,6 @@ function initwrapper() {
             user = $sender.closest('.user').find('a:first').text() || $entry.closest('.user').find('a:first').text() || $thing.closest('.user').find('a:first').text();
         }
 
-
         // If we still don't have a sub, we're in mod mail, or PMs.
         if (TBUtils.isModmail || $sender.closest('.message-parent')[0] !== undefined) {
             // Change it to use the parent's title.
@@ -979,7 +978,7 @@ function initwrapper() {
         // If the permalink is relative, stick the current domain name in.
         if (permalink.slice(0) == "/")
         {
-        	permalink = TBUtils.baseDomain + permalink
+            permalink = TBUtils.baseDomain + permalink
         }
 
         var info = {
@@ -1008,7 +1007,6 @@ function initwrapper() {
             mod: TBUtils.logged
         };
         //$.log(info, false, SHORTNAME);
-
         return info;
     };
 

--- a/extension/data/tbutils.js
+++ b/extension/data/tbutils.js
@@ -976,7 +976,7 @@ function initwrapper() {
             approved_by = approved_text.match(/by\s(.+?)\s/) || '';
 
         // If the permalink is relative, stick the current domain name in.
-        if (permalink.slice(0) == "/")
+        if (permalink.slice(0,1) == "/")
         {
             permalink = TBUtils.baseDomain + permalink
         }

--- a/extension/data/tbutils.js
+++ b/extension/data/tbutils.js
@@ -957,8 +957,6 @@ function initwrapper() {
                     subreddit = $thing.closest('.message-parent').find('.correspondent.reddit.rounded a').text()
                 }
             }
-
-
         }
 
         // A recent reddit change makes subreddit names sometimes start with "/r/".
@@ -977,6 +975,12 @@ function initwrapper() {
 
         var approved_text = $entry.find('.approval-checkmark').attr('title') || $thing.find('.approval-checkmark').attr('title') || '',
             approved_by = approved_text.match(/by\s(.+?)\s/) || '';
+
+        // If the permalink is relative, stick the current domain name in.
+        if (permalink.slice(0) == "/")
+        {
+        	permalink = TBUtils.baseDomain + permalink
+        }
 
         var info = {
             subreddit: subreddit,
@@ -1004,6 +1008,7 @@ function initwrapper() {
             mod: TBUtils.logged
         };
         //$.log(info, false, SHORTNAME);
+
         return info;
     };
 


### PR DESCRIPTION
See https://www.reddit.com/r/toolbox/comments/5kl8qf/inconsistent_log_sub_posting/ for more details.

Basically if you mouse over the Comments link on a post Reddit replaces the href with the data-href-url attribute.  Original href is absolute with domain name.  data-href-url is not.  Reddit doesn't allow you to submit a post to a relative URL so you won't be able to log the removal of a post you mouse'd over the "comments" link of.

This just sees if the link is a relative URL and pre-pends the current domain to it.