### PR TITLE
Add version_name to manifest

### DIFF
--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -5,6 +5,7 @@
     "short_name": "toolbox",
     "description": "A set of tools to be used by moderators on reddit in order to make their jobs easier.",
     "version": "3.6.5",
+    "version_name": "3.6.5: \"Communicating Cat\"",
     "options_page": "data/background/options.html",
     "applications": {
         "gecko": {


### PR DESCRIPTION
I just [discovered this](https://developer.chrome.com/extensions/manifest/version) and thought of toolbox.

In Chrome:

![image](https://cloud.githubusercontent.com/assets/7673145/26292096/55961272-3e81-11e7-8c9a-97ad23c7ce80.png)

It's ignored in Firefox and Edge.