### PR TITLE
Add comment locking functionality

### DIFF
--- a/extension/Info.plist
+++ b/extension/Info.plist
@@ -80,6 +80,7 @@
 				<string>data/modules/achievements.js</string>
 				<string>data/modules/trouble.js</string>
 				<string>data/modules/queuetools.js</string>
+				<string>data/modules/commentlock.js</string>
 				<string>data/tbmoduleinit.js</string>
 			</array>
 		</dict>

--- a/extension/data/modules/commentlock.js
+++ b/extension/data/modules/commentlock.js
@@ -1,0 +1,72 @@
+function commentlock() {
+    var self = new TB.Module('Comment Lock');
+    self.shortname = 'CommentLock';
+
+    //Default settings
+    self.settings['enabled']['default'] = true;
+
+
+    self.init = function() {
+        if (TBUtils.isModmail) {
+            return;
+        }
+        if (!TB.utils.isMod) {
+                return;
+        }
+
+        $('body').on('click', '.comment-lock-button', async function (event) {
+            var $lockButton = $(event.target);
+
+            var action = $lockButton.attr('tb-action');
+            var info = TB.utils.getThingInfo(this, true),
+            data = 'id='+info.id;
+            try{
+                await TBUtils.apiOauthPOST('api/'+action,data);
+                var newAction = action == 'lock' ? 'unlock' : 'lock';
+                $lockButton.attr('tb-action', newAction);
+                $lockButton.text(newAction);
+            }
+            catch(error){
+                self.log(`Error toggling lock on comment: ${error}`);
+            }
+        });
+
+        // NER support.
+        window.addEventListener('TBNewThings', function () {
+            self.run();
+        });
+
+        self.run();
+    };
+
+    self.processComment = function (comment) {
+        var $comment = $(comment);
+        if (!$comment.hasClass('lock-button')) {
+        // Add the class so we don't add buttons twice.
+            $comment.addClass('lock-button');
+            var action = 'lock';
+            if($comment.find('.locked-tagline').length > 0){
+                action = 'unlock';
+            }
+           
+            $comment.find('ul.buttons li:last')
+                .after(`<li><a href="javascript:;" tb-action="${action}" class="comment-lock-button">${action}</a></li>`)
+        }
+    };
+
+    // need this for RES NER support
+    self.run = function () {
+
+        var $comments = $('div.comment:not(.lock-button)');
+        TB.utils.forEachChunked($comments, 15, 650, self.processComment);
+    };
+
+
+    TB.register_module(self);
+}
+
+(function() {
+    window.addEventListener('TBModuleLoaded', function () {
+        commentlock();
+    });
+})();

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -4,8 +4,8 @@
     "author": "toolbox team",
     "short_name": "toolbox",
     "description": "A set of tools to be used by moderators on reddit in order to make their jobs easier.",
-    "version": "3.8.2",
-    "version_name": "3.8.2: \"Cleaning Cockcroach\"",
+    "version": "3.8.3",
+    "version_name": "3.8.3: \"Cleaning Cockcroach\"",
     "options_page": "data/background/options.html",
     "applications": {
         "gecko": {
@@ -119,6 +119,7 @@
                 "data/modules/achievements.js",
                 "data/modules/trouble.js",
                 "data/modules/queuetools.js",
+                "data/modules/commentlock.js",
                 "data/tbmoduleinit.js"
             ]
         }


### PR DESCRIPTION
This is native in the Redesign so the functionality doesn't have to be ported over and can be left to die in this branch.

Stupidly simple module that just adds a "lock" button after "distinguish" that locks or unlocks a comment